### PR TITLE
 Add BigNum money compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,5 +11,5 @@
         "Steamodded (>=1.0.0~ALPHA-1304a)"
     ],
     "conflicts": [],
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
Fixes crash caused by `G.GAME.dollars` being a table instead of a number, which results in a `cannot compare with table` error.